### PR TITLE
[issue 20] - Fixing WildflyApplicationConfiguration::getWildflyApplicationTargetDistributionProfile

### DIFF
--- a/core/src/main/java/org/jboss/intersmash/tests/wildfly/WildflyApplicationConfiguration.java
+++ b/core/src/main/java/org/jboss/intersmash/tests/wildfly/WildflyApplicationConfiguration.java
@@ -297,10 +297,12 @@ public interface WildflyApplicationConfiguration {
 	static String getWildflyApplicationTargetDistributionProfile() {
 		String targetDistribution = "wildfly-target-distribution.";
 		final String buildStream = System.getProperty("wildfly-build-stream", "wildfly-latest");
-		switch (buildStream) {
-			case "jboss-eap.81" -> targetDistribution = targetDistribution.concat("jboss-eap");
-			case "jboss-eap-xp.6" -> targetDistribution = targetDistribution.concat("jboss-eap-xp");
-			default -> targetDistribution = targetDistribution.concat("community");
+		if (buildStream.startsWith("jboss-eap-xp.")) {
+			targetDistribution = targetDistribution.concat("jboss-eap-xp");
+		} else if (buildStream.startsWith("jboss-eap.")) {
+			targetDistribution = targetDistribution.concat("jboss-eap");
+		} else {
+			targetDistribution = targetDistribution.concat("community");
 		}
 		return String.format("-P%s", targetDistribution);
 	}


### PR DESCRIPTION
## Description
Fixing WildflyApplicationConfiguration::getWildflyApplicationTargetDistributionProfileationTargetDistributionProfile in order to evaluate generic jboss-eap. and jboss-eap-xp. build stream profiles

Fixes #20



**Validation jobs**:

- :white_check_mark:  Internal job name: **eap-8.x-cross-product-openshift-wildfly-openjdk21-kafka**, run: **9**
- :white_check_mark:  Internal job name: **eap-8.x-cross-product-openshift-jboss-eap-xp-openjdk21-kafka**, run: **11**

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [x] I tested my code in OpenShift
