### PR TITLE
[issue 24] - Externalize application repository URL and branch

### DIFF
--- a/testsuite/wildfly-microprofile-reactive-messaging-kafka/src/test/java/org/jboss/intersmash/tests/wildfly/microprofile/reactive/messaging/kafka/WildflyMicroProfileReactiveMessagingPerConnectorSecuredApplication.java
+++ b/testsuite/wildfly-microprofile-reactive-messaging-kafka/src/test/java/org/jboss/intersmash/tests/wildfly/microprofile/reactive/messaging/kafka/WildflyMicroProfileReactiveMessagingPerConnectorSecuredApplication.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jboss.intersmash.IntersmashConfig;
 import org.jboss.intersmash.application.input.BuildInput;
 import org.jboss.intersmash.application.input.BuildInputBuilder;
 import org.jboss.intersmash.application.openshift.WildflyImageOpenShiftApplication;
@@ -57,8 +58,8 @@ public class WildflyMicroProfileReactiveMessagingPerConnectorSecuredApplication
 		// Set up the Reactive-messaging deployment.
 		String applicationDir = "wildfly/microprofile-reactive-messaging-kafka";
 		buildInput = new BuildInputBuilder()
-				.uri("https://github.com/Intersmash/intersmash-applications.git")
-				.ref("main")
+				.uri(IntersmashConfig.deploymentsRepositoryUrl())
+				.ref(IntersmashConfig.deploymentsRepositoryRef())
 				.build();
 
 		clientSecret = OpenShifts.master().getSecret("amq-streams-cluster-ca-cert");


### PR DESCRIPTION
## Description
Changing the waythe application repository and branch are set, to leverage `IntersmashConfig` properties, so that it can be externalized and made available to the `mvn` process.

Fixes #24 

- :white_check_mark:  Internal job name: **eap-8.x-cross-product-openshift-wildfly-openjdk21-kafka**, run: **14**
- :white_check_mark:  Internal job name: **eap-8.x-cross-product-openshift-jboss-eap-xp-openjdk21-kafka**, run: **15**

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [x] I tested my code in OpenShift
