### PR TITLE
[issue 28] - Fixing Maven mirror URL managment in WildflyApplicationConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Additionally, the Maven Failsafe Plugin will use the
 file in order to configure the Intersmash framework, so that JBoss EAP XP cloud deliverables - e.g.: images and Helm
 Charts -  will be used during the test execution.
 
+- `wildfly-target-distribution.jboss-eap-xp.merged-channel`
+
+Similar to `wildfly-target-distribution.jboss-eap-xp` but when forwarded to the remote s2i build, it will enable 
+a dedicated profile to provision the tested JBoss EAP XP application by using a single - i.e. merged - channel 
+manifest, as when testing JBoss EAP candidate releases. 
+
 Such values can be overridden via system properties.
 
 **IMPORTANT**:

--- a/core/src/main/java/org/jboss/intersmash/tests/wildfly/WildflyApplicationConfiguration.java
+++ b/core/src/main/java/org/jboss/intersmash/tests/wildfly/WildflyApplicationConfiguration.java
@@ -36,6 +36,8 @@ public interface WildflyApplicationConfiguration {
 	String WILDFLY_MAVEN_PLUGIN_VERSION = "wildfly-maven-plugin.version";
 	String WILDFLY_KEYCLOAK_SAML_ADAPTER_FEATURE_PACK_VERSION = "wildfly.keycloak-saml-adapter-feature-pack.version";
 	String MAVEN_MIRROR_URL = "maven-mirror.url";
+	String MAVEN_RESOLVER_TRANSPORT = "maven.resolver.transport";
+	String MAVEN_WAGON_HTTP_SSL_INSECURE = "maven.wagon.http.ssl.insecure";
 
 	default String wildflyMavenPluginGroupId() {
 		return System.getProperty(WILDFLY_MAVEN_PLUGIN_GROUPID);
@@ -83,6 +85,14 @@ public interface WildflyApplicationConfiguration {
 
 	default String getMavenMirrorUrl() {
 		return System.getProperty(MAVEN_MIRROR_URL);
+	}
+
+	default String getMavenResolverTransport() {
+		return System.getProperty(MAVEN_RESOLVER_TRANSPORT);
+	}
+
+	default String getMavenWagonHttpSslInsecure() {
+		return System.getProperty(MAVEN_WAGON_HTTP_SSL_INSECURE);
 	}
 
 	default String keycloakSamlAdapterFeaturePackVersion() {
@@ -284,11 +294,15 @@ public interface WildflyApplicationConfiguration {
 						: (" -D" + this.bomsEeServerVersionPropertyName() + "=" + this.bomsEeServerVersion()))));
 		// let's forward the distribution for building the application.
 		result = result.concat(" " + getWildflyApplicationTargetDistributionProfile());
-		// a maven mirror for testable artifacts, i.e. which are not released yet, can
-		// be provided
-		result = result.concat((StringUtils.isBlank(this.getMavenMirrorUrl())
+		// wagon related properties
+		final String mavenResolverTransport = this.getMavenResolverTransport();
+		result = result.concat(StringUtils.isBlank(mavenResolverTransport)
 				? ""
-				: " -Dmaven-mirror.url=" + this.getMavenMirrorUrl()));
+				: String.format(" -D%s=%s", MAVEN_RESOLVER_TRANSPORT, mavenResolverTransport));
+		final String mavenWagonHttpSslInsecure = this.getMavenWagonHttpSslInsecure();
+		result = result.concat(StringUtils.isBlank(mavenWagonHttpSslInsecure)
+				? ""
+				: String.format(" -D%s=%s", MAVEN_WAGON_HTTP_SSL_INSECURE, mavenWagonHttpSslInsecure));
 		return result;
 	}
 

--- a/core/src/test/java/org/jboss/intersmash/tests/wildfly/EapXpApplicationBuildProfilesTest.java
+++ b/core/src/test/java/org/jboss/intersmash/tests/wildfly/EapXpApplicationBuildProfilesTest.java
@@ -48,4 +48,22 @@ public class EapXpApplicationBuildProfilesTest {
 		// Assert
 		Assertions.assertTrue(mavenArgs.contains(" -Pwildfly-target-distribution.jboss-eap-xp"));
 	}
+
+	/**
+	 * Verifies that the correct properties are generated to be passed to an OpenShift s2i build which should produce
+	 * a JBoss EAP XP application, provisioned with a single - i.e. merged - channel manifest.
+	 */
+	@Test
+	void generatedMavenArgsIncludeValidProfilesWhenMergedChannelManifestIsUsed() {
+		// Arrange
+		systemProperties.set("wildfly-target-distribution", "jboss-eap-xp.merged-channel");
+
+		// Act
+		WildflyApplicationConfiguration app = new WildflyApplicationConfiguration() {
+		};
+		final String mavenArgs = app.generateAdditionalMavenArgs();
+
+		// Assert
+		Assertions.assertTrue(mavenArgs.contains(" -Pwildfly-target-distribution.jboss-eap-xp.merged-channel"));
+	}
 }

--- a/core/src/test/java/org/jboss/intersmash/tests/wildfly/WildflyApplicationConfigurationTest.java
+++ b/core/src/test/java/org/jboss/intersmash/tests/wildfly/WildflyApplicationConfigurationTest.java
@@ -51,7 +51,6 @@ public class WildflyApplicationConfigurationTest {
 		systemProperties.set("wildfly.ee-channel.groupId", "wildfly.ee-channel.groupId.NONE_FOR_WILDFLY");
 		systemProperties.set("wildfly.ee-channel.artifactId", "wildfly.ee-channel.artifactId.NONE_FOR_WILDFLY");
 		systemProperties.set("wildfly.ee-channel.version", "wildfly.ee-channel.version.NONE_FOR_WILDFLY");
-		systemProperties.set("bom.wildfly-ee.version", "30.0.0.Final");
 
 		// Act
 		WildflyApplicationConfiguration app = new WildflyApplicationConfiguration() {
@@ -98,6 +97,8 @@ public class WildflyApplicationConfigurationTest {
 		systemProperties.set("wildfly.ee-channel.artifactId", "wildfly.ee-channel.artifactId.NONE_FOR_WILDFLY");
 		systemProperties.set("wildfly.ee-channel.version", "wildfly.ee-channel.version.NONE_FOR_WILDFLY");
 		systemProperties.set("bom.wildfly-ee.version", "30.0.0.Final");
+		systemProperties.set("maven.wagon.http.ssl.insecure", "true");
+		systemProperties.set("maven.resolver.transport", "wagon");
 
 		// Act
 		WildflyApplicationConfiguration app = new WildflyApplicationConfiguration() {
@@ -130,5 +131,7 @@ public class WildflyApplicationConfigurationTest {
 				mavenArgs.contains(String.format(" -Dwildfly.ee-channel.version=%s", app.eeChannelVersion())));
 		Assertions.assertTrue(
 				mavenArgs.contains(String.format(" -Dbom.wildfly-ee.version=%s", app.bomsEeServerVersion())));
+		Assertions.assertTrue(mavenArgs.contains("-Dmaven.wagon.http.ssl.insecure=true"));
+		Assertions.assertTrue(mavenArgs.contains("-Dmaven.resolver.transport=wagon"));
 	}
 }

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -148,5 +148,33 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <!-- Configuration settings for testing JBoss EAP XP -->
+            <id>wildfly-target-distribution.jboss-eap-xp.merged-channel</id>
+            <properties>
+                <!-- set the WildFly target distribution to JBoss EAP -->
+                <intersmash.test.wildfly-target-distribution>jboss-eap-xp.merged-channel</intersmash.test.wildfly-target-distribution>
+            </properties>
+            <!-- Submodules which are built when testing JBoss EAP XP -->
+            <modules>
+                <module>wildfly-microprofile-reactive-messaging-kafka</module>
+            </modules>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <!-- JBoss EAP XP tests are only executed on OpenShift -->
+                                <xtf.global_test_properties.path>global-test.jboss-eap-xp.openshift.properties</xtf.global_test_properties.path>
+                            </systemPropertyVariables>
+                            <!-- Exclude Kubernetes tests, when the profile for running tests on OpenShift is enabled  -->
+                            <excludedGroups>k8s</excludedGroups>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/testsuite/wildfly-microprofile-reactive-messaging-kafka/src/test/java/org/jboss/intersmash/tests/wildfly/microprofile/reactive/messaging/kafka/WildflyMicroProfileReactiveMessagingPerConnectorSecuredApplication.java
+++ b/testsuite/wildfly-microprofile-reactive-messaging-kafka/src/test/java/org/jboss/intersmash/tests/wildfly/microprofile/reactive/messaging/kafka/WildflyMicroProfileReactiveMessagingPerConnectorSecuredApplication.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.assertj.core.util.Strings;
 import org.jboss.intersmash.IntersmashConfig;
 import org.jboss.intersmash.application.input.BuildInput;
 import org.jboss.intersmash.application.input.BuildInputBuilder;
@@ -96,9 +97,16 @@ public class WildflyMicroProfileReactiveMessagingPerConnectorSecuredApplication
 				new EnvVarBuilder().withName("MAVEN_S2I_ARTIFACT_DIRS")
 						.withValue(applicationDir + "/target")
 						.build());
-
-		final String mavenAdditionalArgs = generateAdditionalMavenArgs()
+		String mavenAdditionalArgs = generateAdditionalMavenArgs()
 				.concat(" -pl " + applicationDir + " -am");
+		final String mavenMirrorUrl = this.getMavenMirrorUrl();
+		if (!Strings.isNullOrEmpty(mavenMirrorUrl)) {
+			environmentVariables.add(
+					new EnvVarBuilder().withName("MAVEN_MIRROR_URL")
+							.withValue(mavenMirrorUrl)
+							.build());
+			mavenAdditionalArgs = mavenAdditionalArgs.concat(" -Dinsecure.repositories=WARN");
+		}
 		environmentVariables.add(
 				new EnvVarBuilder().withName("MAVEN_ARGS_APPEND")
 						.withValue(mavenAdditionalArgs)


### PR DESCRIPTION
## Description
Changes fix the way a deployed application is configured, specifically with respect to the `MAVEN_MIRROR_URL` environment variable, which so far was passed as a system property to the OpenSHift s2i build, which in turn makes no sense. 
Besides, when provided, additional properties are forwarded to the s2i build via the `MAVEN_ARGS_APPEND` environment variable, i.e. `wagon` related properties to avoid the well known PKIX security exception and when `MAVEN_MIRROR_URL` is set `-Dinsecure.repositories=WARN` is also set to avoid failing the build when using an `http` repository.

An additional commit adds a new profile, i.e. `wildfly-target-distribution.jboss-eap-xp.merged-channel` which - when enabled - allows provisioning JBoss EAP XP application with a single (i.e. _merged_) channel manifest. This is a common use case when testing JBoss EAP XP candidate releases, and is completed by the work done on the intersmash-applications side, see https://github.com/Intersmash/intersmash-applications/pull/43 


Fixes #28 

**OpenShift validation checks**:
- :white_check_mark:  Internal job name: **eap-8.x-cross-product-openshift-jboss-eap-xp-openjdk21-kafka**, run: **26** - built with custom (CR) XP 6 bits, and a single channel manifest.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [ ] I tested my code in OpenShift
