### PR TITLE
[issues-63] Create a WildFly Test that interacts with an external Keycloak service to secure EJB resources with SAML

### DIFF
--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -26,6 +26,11 @@ which is configured to allow SAML Single-sign-on in order to secure the applicat
 
 The deployed application descriptor sets the necessary environment variables described in [keycloak/2.0/module.yaml](https://github.com/wildfly/wildfly-cekit-modules/blob/main/jboss/container/wildfly/launch/keycloak/2.0/module.yaml) to configure the connection to the Keycloak service and to trigger the automatic SAML Client registration.
 
+## WildFly EJB + SAML Adapter client + Keycloak
+
+This test is basically the same as [WildFly SAML Adapter client + Keycloak](#wildfly-saml-adapter-client--keycloak) and
+also tests that the EJB layer is correctly configured and authentication and authorization data is propagated to the EJB layer;
+
 ## WildFly Web cache offload + Infinispan
 
 This tests validates an interoperability use case based on a WildFly/JBoss EAP/JBoss EAP XP application which

--- a/testsuite/src/test/java/org/jboss/intersmash/tests/wildfly/keycloak/saml/adapter/WildFlyKeycloakSamlAdapterEjbIT.java
+++ b/testsuite/src/test/java/org/jboss/intersmash/tests/wildfly/keycloak/saml/adapter/WildFlyKeycloakSamlAdapterEjbIT.java
@@ -1,0 +1,264 @@
+/**
+* Copyright (C) 2025 Red Hat, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.jboss.intersmash.tests.wildfly.keycloak.saml.adapter;
+
+import static org.assertj.core.api.Assertions.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.gargoylesoftware.htmlunit.ElementNotFoundException;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlElement;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import cz.xtf.core.http.Https;
+import cz.xtf.core.openshift.OpenShifts;
+import cz.xtf.junit5.annotations.OpenShiftRecorder;
+import cz.xtf.junit5.listeners.ProjectCreator;
+import io.fabric8.kubernetes.api.model.Pod;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.jboss.intersmash.annotations.Intersmash;
+import org.jboss.intersmash.annotations.Service;
+import org.jboss.intersmash.annotations.ServiceUrl;
+import org.jboss.intersmash.tests.junit.annotations.EapTest;
+import org.jboss.intersmash.tests.junit.annotations.EapXpTest;
+import org.jboss.intersmash.tests.junit.annotations.KeycloakTest;
+import org.jboss.intersmash.tests.junit.annotations.OpenShiftTest;
+import org.jboss.intersmash.tests.junit.annotations.WildflyTest;
+import org.jboss.intersmash.tests.wildfly.elytron.oidc.client.keycloak.KeycloakPostgresqlApplication;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Integration tests for WildFly/JBoss EAP with Keycloak SAML Adapter.
+ * <p>
+ * This test class validates the integration between WildFly/JBoss EAP and Keycloak/RHBK
+ * using SAML-based authentication. It tests:
+ * <ul>
+ *   <li>Automatic SAML client registration with Keycloak</li>
+ *   <li>Successful authentication and access to protected resources</li>
+ *   <li>Role-based access control and forbidden access scenarios</li>
+ * </ul>
+ * </p>
+ * <p>
+ * The test deploys a complete environment with PostgreSQL, Keycloak, and a
+ * SAML-secured WildFly/JBoss EAP application, verifying the entire authentication flow.
+ * </p>
+ */
+@OpenShiftRecorder(resourceNames = { BasicKeycloakOperatorApplication.APP_NAME,
+		WildflyWithKeycloakSamlAdapterEjbApplication.APP_NAME })
+@KeycloakTest
+@WildflyTest
+@EapTest
+@EapXpTest
+@OpenShiftTest
+@ExtendWith(ProjectCreator.class)
+@Slf4j
+@Intersmash({
+		@Service(KeycloakPostgresqlApplication.class),
+		@Service(BasicKeycloakOperatorApplication.class),
+		@Service(WildflyWithKeycloakSamlAdapterEjbApplication.class)
+})
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class WildFlyKeycloakSamlAdapterEjbIT {
+	/** HTML element ID containing the authenticated username from the Servlet layer . */
+	private static final String HTML_ID_WITH_USERNAME = "username";
+	/** HTML element ID containing the authenticated username from the EJB layer. */
+	private static final String HTML_ID_WITH_USERNAME_EJB = "usernameEjb";
+
+	/** Route URL for the WildFly/JBoss EAP application. */
+	@ServiceUrl(WildflyWithKeycloakSamlAdapterEjbApplication.class)
+	private String wildflyApplicationRouteUrl;
+
+	private static boolean samlClientCreated = false;
+	private static boolean wildflyApplicationIsRunning = false;
+
+	/**
+	 * Verifies that the SAML client has been automatically created in Keycloak.
+	 * <p>
+	 * This test checks the WildFly/JBoss EAP pod logs to confirm that the SAML client
+	 * was successfully registered with the Keycloak realm after the "routeview"
+	 * role was added to the service account.
+	 * </p>
+	 */
+	@Test
+	@Order(1)
+	public void testSamlClientCreation() {
+		Pod wildflyPod = OpenShifts.master().getLabeledPods("name", WildflyWithKeycloakSamlAdapterEjbApplication.APP_NAME)
+				.get(0);
+		Assertions.assertNotNull(wildflyPod, "An WildFly/JBoss EAP instance should exist");
+		String podLog = OpenShifts.master().getPodLog(wildflyPod);
+		Assertions.assertTrue(podLog.contains("INFO Registered saml client for module"),
+				"The WildFly/JBoss EAP pod logs should report that the SAML client has been created");
+		samlClientCreated = true;
+	}
+
+	/**
+	 * Verifies that the WildFly/JBoss EAP application is running and accessible.
+	 * <p>
+	 * This test performs a health check by verifying that the application
+	 * route returns an HTTP OK (200) status code.
+	 * </p>
+	 */
+	@Test
+	@Order(2)
+	public void testWildflyApplicationIsRunning() {
+		log.info("https base url: {}", wildflyApplicationRouteUrl);
+		Https.doesUrlReturnOK(wildflyApplicationRouteUrl);
+		wildflyApplicationIsRunning = true;
+	}
+
+	/**
+	 * Tests successful SAML-based authentication and access to protected resources.
+	 * <p>
+	 * This test verifies the complete SAML authentication flow:
+	 * <ol>
+	 *   <li>User attempts to access a protected resource (profile.jsp)</li>
+	 *   <li>User is redirected to the Keycloak/RHBK login page</li>
+	 *   <li>User successfully logs in with valid credentials</li>
+	 *   <li>User is redirected back to the protected resource</li>
+	 *   <li>The page displays the authenticated user principal</li>
+	 * </ol>
+	 * </p>
+	 *
+	 * @throws IOException if an I/O error occurs during the test
+	 */
+	@Test
+	@Order(3)
+	public void testAccessOk() throws IOException {
+		assumeTrue(samlClientCreated && wildflyApplicationIsRunning);
+
+		String wildflySecuredPage = wildflyApplicationRouteUrl + "/profile.jsp";
+		log.info("https url: {}", wildflySecuredPage);
+
+		try (final WebClient webClient = new WebClient()) {
+			webClient.getOptions().setUseInsecureSSL(true);
+			webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+
+			HtmlPage keycloakLoginPage = webClient.getPage(wildflySecuredPage);
+			KeycloakLoginPageUtilities.assertIsExpectedRealm(keycloakLoginPage, BasicKeycloakOperatorApplication.REALM_NAME);
+
+			HtmlPage securedPage = (HtmlPage) KeycloakLoginPageUtilities.makeLogin(keycloakLoginPage,
+					BasicKeycloakOperatorApplication.USER_NAME,
+					BasicKeycloakOperatorApplication.USER_PASSWORD);
+			// first we check we landed on the expected JSP page
+			assertIsSecuredPage(securedPage);
+			// then we check the JSP page received the expected security info from the servlet layer
+			assertIsUserPrincipal(securedPage, HTML_ID_WITH_USERNAME);
+			// then we check the JSP page received the expected security info from the EJB layer
+			assertIsUserPrincipal(securedPage, HTML_ID_WITH_USERNAME_EJB);
+		}
+	}
+
+	/**
+	 * Tests that access is denied for users without required roles.
+	 * <p>
+	 * This test verifies the SAML authentication flow with role-based access control:
+	 * <ol>
+	 *   <li>User attempts to access a protected resource (profile.jsp)</li>
+	 *   <li>User is redirected to the Keycloak/RHBK login page</li>
+	 *   <li>User successfully logs in with valid credentials</li>
+	 *   <li>User is redirected back to the application</li>
+	 *   <li>Access is denied with a Forbidden page due to missing required role</li>
+	 * </ol>
+	 * </p>
+	 *
+	 * @throws IOException if an I/O error occurs during the test
+	 */
+	@Test
+	@Order(4)
+	public void testForbidden() throws IOException {
+		assumeTrue(samlClientCreated && wildflyApplicationIsRunning);
+
+		String wildflySecuredPage = wildflyApplicationRouteUrl + "/profile.jsp";
+		log.info("https url: {}", wildflySecuredPage);
+
+		try (final WebClient webClient = new WebClient()) {
+			webClient.getOptions().setUseInsecureSSL(true);
+			webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+
+			HtmlPage keycloakLoginPage = webClient.getPage(wildflySecuredPage);
+			KeycloakLoginPageUtilities.assertIsExpectedRealm(keycloakLoginPage, BasicKeycloakOperatorApplication.REALM_NAME);
+
+			HtmlPage securedPage = (HtmlPage) KeycloakLoginPageUtilities.makeLogin(keycloakLoginPage,
+					BasicKeycloakOperatorApplication.ANOTHER_USER_NAME,
+					BasicKeycloakOperatorApplication.ANOTHER_USER_PASSWORD);
+			assertIsForbidden(securedPage);
+		}
+	}
+
+	/**
+	 * Asserts that the page displays a "Forbidden" message.
+	 * <p>
+	 * This method verifies that access was denied to a resource,
+	 * typically due to insufficient permissions or missing required roles.
+	 * </p>
+	 *
+	 * @param securedPage the page to check for forbidden access
+	 * @throws AssertionError if the page does not contain the "Forbidden" message
+	 */
+	protected void assertIsForbidden(HtmlPage securedPage) {
+		assertThat("The HTML page is not the expected Forbidden page!",
+				securedPage.getByXPath("//body//text()").get(0).toString().equalsIgnoreCase("Forbidden"));
+	}
+
+	/**
+	 * Asserts that the page is the expected secured page (profile.jsp).
+	 * <p>
+	 * This method verifies that after successful authentication, the user
+	 * was redirected to the correct protected resource.
+	 * </p>
+	 *
+	 * @param securedPage the page to verify
+	 * @throws AssertionError if the page URL does not contain "profile.jsp"
+	 */
+	protected void assertIsSecuredPage(HtmlPage securedPage) {
+		assertThat(
+				"The page the client was redirected to, isn't the one expected",
+				securedPage.getUrl().toString(), containsStringIgnoringCase("profile.jsp"));
+	}
+
+	/**
+	 * Asserts that the secured page contains the authenticated user principal.
+	 * <p>
+	 * This method verifies that the HTML element with the specified ID contains
+	 * a valid user principal value matching the expected GUID pattern (G-[UUID]).
+	 * This confirms that the SAML authentication was successful and the user
+	 * identity was properly propagated to the application.
+	 * </p>
+	 *
+	 * @param securedPage the secured page containing user information
+	 * @param htmlId the HTML element ID that should contain the username
+	 * @throws AssertionError if the element is not found or doesn't match the expected pattern
+	 */
+	protected void assertIsUserPrincipal(HtmlPage securedPage, String htmlId) {
+		try {
+			HtmlElement username = securedPage.getHtmlElementById(htmlId);
+			assertThat(
+					String.format("The HTML element with ID (%s) does not contain expected %s value", htmlId,
+							BasicKeycloakOperatorApplication.USER_NAME),
+					username.getTextContent(), matchesPattern("G-[a-zA-Z0-9\\-]{36}"));
+		} catch (ElementNotFoundException exception) {
+			fail("The element with id " + exception.getAttributeValue() + " was not found");
+		}
+	}
+}

--- a/testsuite/src/test/java/org/jboss/intersmash/tests/wildfly/keycloak/saml/adapter/WildflyWithKeycloakSamlAdapterEjbApplication.java
+++ b/testsuite/src/test/java/org/jboss/intersmash/tests/wildfly/keycloak/saml/adapter/WildflyWithKeycloakSamlAdapterEjbApplication.java
@@ -1,0 +1,347 @@
+/**
+* Copyright (C) 2025 Red Hat, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.jboss.intersmash.tests.wildfly.keycloak.saml.adapter;
+
+import cz.xtf.core.openshift.OpenShifts;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.util.Strings;
+import org.jboss.intersmash.IntersmashConfig;
+import org.jboss.intersmash.application.input.BuildInput;
+import org.jboss.intersmash.application.input.BuildInputBuilder;
+import org.jboss.intersmash.application.openshift.WildflyImageOpenShiftApplication;
+import org.jboss.intersmash.tests.wildfly.WildflyApplicationConfiguration;
+import org.jboss.intersmash.tests.wildfly.util.SimpleCommandLineBasedKeystoreGenerator;
+import org.jboss.intersmash.tests.wildfly.web.cache.offload.infinispan.util.OpenShiftBinaryClient;
+
+/**
+ * WildFly/JBoss EAP Application configured with Keycloak SAML Adapter for authentication.
+ * <p>
+ * This application deploys a WildFly/JBoss EAP instance that:
+ * <ul>
+ *   <li>Uses the Keycloak SAML adapter for securing web resources</li>
+ *   <li>Configures keystores and truststores for SAML encryption and signing</li>
+ *   <li>Connects to an external Keycloak/RHBK service for authentication</li>
+ *   <li>Automatically registers as a SAML client with the Keycloak realm</li>
+ *   <li>Supports HTTPS communication with the Keycloak service</li>
+ * </ul>
+ * </p>
+ * <p>
+ * The application sets up the necessary permissions for KUBE_PING clustering and route discovery,
+ * configures Maven build parameters, and creates the required Kubernetes secrets for keystores.
+ * </p>
+ */
+@Slf4j
+public class WildflyWithKeycloakSamlAdapterEjbApplication
+		implements WildflyImageOpenShiftApplication, WildflyApplicationConfiguration {
+	/** Application name used for labeling and resource identification. */
+	public static final String APP_NAME = "keycloak-saml-adapter-ejb";
+
+	/** Certificate name used for SAML encryption and signing. */
+	public static final String SSO_SAML_CERTIFICATE_NAME = APP_NAME;
+
+	/** Keystore password for SAML certificates. */
+	public static final String SSO_SAML_KEYSTORE_PASSWORD = "1234password";
+
+	/** Directory path for TLS certificates and keystores within the container. */
+	private static final String TLS_CERTIFICATE_DIR_NAME = "/etc/secrets";
+
+	/** Build input configuration for the WildFly/JBoss EAP S2I build. */
+	private final BuildInput buildInput;
+
+	/** List of environment variables for the WildFly/JBoss EAP container. */
+	private final List<EnvVar> environmentVariables = new ArrayList<>();
+
+	/** List of Kubernetes secrets for keystores and truststores. */
+	private final List<Secret> secrets = new ArrayList<>();
+
+	/**
+	 * Sets up the OpenShift namespace with required permissions for the WildFly/JBoss EAP application.
+	 * <p>
+	 * This method configures:
+	 * <ul>
+	 *   <li>The 'view' role for the default service account (required for KUBE_PING clustering)</li>
+	 *   <li>A 'routeview' role with permissions to list routes (required for route discovery)</li>
+	 * </ul>
+	 * </p>
+	 * <p>
+	 * Without these permissions, JGroups clustering and the SAML adapter's route discovery
+	 * feature will not function properly.
+	 * </p>
+	 *
+	 * @throws IllegalStateException if the OpenShift commands fail to execute
+	 */
+	public static void setupNamespace() {
+		// KUBE_PING requires this permission, otherwise warning is logged and clustering doesn't work,
+		// an invalidation-cache requires a functioning jgroups cluster.
+		log.debug("Adding role view to default service account...");
+		OpenShifts.master().addRoleToServiceAccount("view", "default");
+
+		// Needed for feature "The Routes discovery" to work;
+		// Instead of using HOSTNAME_HTTPS/S the service account require permission to list routes of project.
+		// Execute the two following commands to permit list routes to service account for current namespace:
+		//   oc create role routeview --verb=list --resource=route
+		//   oc policy add-role-to-user routeview system:serviceaccount:<namespace-name>:default --role-namespace=<namespace-name> -n <namespace-name>
+		// Without this, the following error would be produced:
+		//   "routes.route.openshift.io is forbidden: User system:serviceaccount:appsint-5i7y:default
+		//   cannot list resource routes in API group route.openshift.io in the namespace"
+		log.debug("Adding permission to list routes to default service account...");
+		String error = "ERROR: cannot create and assign the role to the service account";
+		try {
+			// KUBE_PING needs view permissions
+			OpenShifts.master().addRoleToServiceAccount("view", "default");
+			// The app URL is needed for automatic client registration
+			OpenShiftBinaryClient instance = OpenShiftBinaryClient.getInstance();
+			String namespaceName = OpenShifts.master().getNamespace();
+			String serviceAccount = String.format("system:serviceaccount:%s:default", namespaceName);
+			String roleNameSpace = String.format("--role-namespace=%s", namespaceName);
+
+			instance.executeCommand(error, "project", namespaceName);
+			instance.executeCommand(error, "create", "role", "routeview", "--verb=list", "--resource=route");
+			instance.executeCommand(error, "policy", "add-role-to-user", "routeview",
+					serviceAccount, roleNameSpace, "-n", namespaceName);
+		} catch (IllegalStateException e) {
+			log.error("Error during execution OC command: {}", e.getMessage());
+			throw e;
+		}
+	}
+
+	/**
+	 * Constructs a new WildflyWithKeycloakSamlAdapterApplication.
+	 * <p>
+	 * This constructor initializes:
+	 * <ul>
+	 *   <li>OpenShift namespace with required permissions</li>
+	 *   <li>Build input configuration for Maven S2I build</li>
+	 *   <li>Environment variables for SAML adapter configuration</li>
+	 *   <li>Keystores and truststores for SAML encryption and HTTPS communication</li>
+	 *   <li>Kubernetes secrets containing the certificates</li>
+	 * </ul>
+	 * </p>
+	 *
+	 * @throws IOException if certificate generation or file operations fail
+	 */
+	public WildflyWithKeycloakSamlAdapterEjbApplication() throws IOException {
+		setupNamespace();
+
+		String applicationDir = "wildfly/keycloak-saml-adapter-ejb";
+		buildInput = new BuildInputBuilder()
+				.uri(IntersmashConfig.deploymentsRepositoryUrl())
+				.ref(IntersmashConfig.deploymentsRepositoryRef())
+				.build();
+
+		environmentVariables.add(
+				new EnvVarBuilder().withName("MAVEN_S2I_ARTIFACT_DIRS")
+						.withValue(applicationDir + "/target")
+						.build());
+		String mavenAdditionalArgs = generateAdditionalMavenArgs()
+				.concat(" -pl " + applicationDir + " -am");
+		final String mavenMirrorUrl = this.getMavenMirrorUrl();
+		if (!Strings.isNullOrEmpty(mavenMirrorUrl)) {
+			environmentVariables.add(
+					new EnvVarBuilder().withName("MAVEN_MIRROR_URL")
+							.withValue(mavenMirrorUrl)
+							.build());
+			mavenAdditionalArgs = mavenAdditionalArgs.concat(" -Dinsecure.repositories=WARN");
+		}
+		environmentVariables.add(
+				new EnvVarBuilder().withName("MAVEN_ARGS_APPEND")
+						.withValue(mavenAdditionalArgs)
+						.build());
+		// See https://github.com/wildfly/wildfly-cekit-modules/blob/main/jboss/container/wildfly/launch/keycloak/2.0/added/keycloak.sh
+		// for details about how the SSO_* variables are actually used
+		environmentVariables.add(
+				new EnvVarBuilder().withName("SSO_URL")
+						.withValue("https://" + BasicKeycloakOperatorApplication.getRoute())
+						.build());
+		environmentVariables.add(
+				new EnvVarBuilder().withName("SSO_REALM")
+						.withValue(BasicKeycloakOperatorApplication.REALM_NAME)
+						.build());
+		environmentVariables.add(
+				new EnvVarBuilder().withName("SSO_USERNAME")
+						.withValue(BasicKeycloakOperatorApplication.SSO_USERNAME)
+						.build());
+		environmentVariables.add(
+				new EnvVarBuilder().withName("SSO_PASSWORD")
+						.withValue(BasicKeycloakOperatorApplication.SSO_PASSWORD)
+						.build());
+		environmentVariables.add(
+				new EnvVarBuilder().withName("SSO_SAML_LOGOUT_PAGE")
+						.withValue("/index.jsp")
+						.build());
+		environmentVariables.add(
+				new EnvVarBuilder().withName("SCRIPT_DEBUG")
+						.withValue(IntersmashConfig.scriptDebug() != null ? IntersmashConfig.scriptDebug() : "false")
+						.build());
+		environmentVariables.add(
+				new EnvVarBuilder().withName("LOGGING_SCRIPT_DEBUG")
+						.withValue(IntersmashConfig.scriptDebug() != null ? IntersmashConfig.scriptDebug() : "false")
+						.build());
+
+		// Private Key + Self-signed certificate for SAML requests encrypt and SAML assertions decrypt
+		final SimpleCommandLineBasedKeystoreGenerator.CertificateInfo wildflyCertificate = SimpleCommandLineBasedKeystoreGenerator
+				.generateCertificate(
+						OpenShifts.master().generateHostname(APP_NAME),
+						SSO_SAML_CERTIFICATE_NAME,
+						SSO_SAML_KEYSTORE_PASSWORD,
+						SSO_SAML_KEYSTORE_PASSWORD,
+						Collections.emptyList());
+
+		/*
+		    Cryptographic Keys can be used for both:
+		     - HTTP Traffic encryption
+		     - and/or SAML messages signing
+		    See https://www.keycloak.org/securing-apps/saml-galleon-layers#_saml-general-config
+		 */
+
+		// We need to trust Keycloak certificate when communicating over HTTPS
+		final SimpleCommandLineBasedKeystoreGenerator.CertificateInfo keycloakCertificate = SimpleCommandLineBasedKeystoreGenerator
+				.generateCertificate(
+						OpenShifts.master().generateHostname(BasicKeycloakOperatorApplication.APP_NAME),
+						BasicKeycloakOperatorApplication.HTTPS_CERTIFICATE_NAME,
+						BasicKeycloakOperatorApplication.HTTPS_KEYSTORE_PASSWORD,
+						BasicKeycloakOperatorApplication.HTTPS_KEYSTORE_PASSWORD,
+						Collections.emptyList());
+
+		Secret keystoreAndTruststoreSecret = new SecretBuilder()
+				.withNewMetadata()
+				.withName(APP_NAME + "-keystore-and-truststore")
+				.withLabels(Collections.singletonMap("app", APP_NAME))
+				.endMetadata()
+				.addToData(Map.of("keystore.jks",
+						Base64.getEncoder()
+								.encodeToString(FileUtils.readFileToByteArray(wildflyCertificate.keystore.toFile()))))
+				.addToData(Map.of("truststore.pkcs12",
+						Base64.getEncoder()
+								.encodeToString(FileUtils.readFileToByteArray(keycloakCertificate.truststore.toFile()))))
+				.build();
+		secrets.add(keystoreAndTruststoreSecret);
+
+		// SSO_SAML_KEYSTORE_DIR/SSO_SAML_KEYSTORE : together form the complete path to the KeyStore
+		environmentVariables.add(
+				new EnvVarBuilder().withName("SSO_SAML_KEYSTORE_DIR")
+						.withValue(TLS_CERTIFICATE_DIR_NAME)
+						.build());
+		environmentVariables.add(
+				new EnvVarBuilder().withName("SSO_SAML_KEYSTORE")
+						.withValue("keystore.jks")
+						.build());
+		// SSO_SAML_KEYSTORE_PASSWORD : password for both KeyStore and PrivateKey
+		environmentVariables.add(
+				new EnvVarBuilder().withName("SSO_SAML_KEYSTORE_PASSWORD")
+						.withValue(SSO_SAML_KEYSTORE_PASSWORD)
+						.build());
+		// SSO_SAML_CERTIFICATE_NAME : alias for both PrivateKey and Certificate
+		environmentVariables.add(
+				new EnvVarBuilder().withName("SSO_SAML_CERTIFICATE_NAME")
+						.withValue(SSO_SAML_CERTIFICATE_NAME)
+						.build());
+
+		// Set truststore for the SP (the WildFly/JBoss EAP application)
+		environmentVariables.add(
+				new EnvVarBuilder().withName("SSO_TRUSTSTORE")
+						.withValue("truststore.pkcs12")
+						.build());
+		environmentVariables.add(
+				new EnvVarBuilder().withName("SSO_TRUSTSTORE_DIR")
+						.withValue(TLS_CERTIFICATE_DIR_NAME)
+						.build());
+		environmentVariables.add(
+				new EnvVarBuilder().withName("SSO_TRUSTSTORE_CERTIFICATE_ALIAS")
+						.withValue(BasicKeycloakOperatorApplication.HTTPS_CERTIFICATE_NAME)
+						.build());
+		environmentVariables.add(
+				new EnvVarBuilder().withName("SSO_TRUSTSTORE_PASSWORD")
+						.withValue(BasicKeycloakOperatorApplication.HTTPS_KEYSTORE_PASSWORD)
+						.build());
+	}
+
+	/**
+	 * Returns the build input configuration for the WildFly/JBoss EAP S2I build.
+	 *
+	 * @return the build input configuration
+	 */
+	@Override
+	public BuildInput getBuildInput() {
+		return buildInput;
+	}
+
+	/**
+	 * Returns the application name.
+	 *
+	 * @return the application name
+	 */
+	@Override
+	public String getName() {
+		return APP_NAME;
+	}
+
+	/**
+	 * Returns an unmodifiable list of environment variables for the WildFly/JBoss EAP container.
+	 * <p>
+	 * The environment variables include configuration for:
+	 * <ul>
+	 *   <li>Maven build parameters</li>
+	 *   <li>SAML adapter settings (SSO_URL, SSO_REALM, etc.)</li>
+	 *   <li>Keystore and truststore paths and passwords</li>
+	 *   <li>Debug logging settings</li>
+	 * </ul>
+	 * </p>
+	 *
+	 * @return unmodifiable list of environment variables
+	 */
+	@Override
+	public List<EnvVar> getEnvVars() {
+		return Collections.unmodifiableList(environmentVariables);
+	}
+
+	/**
+	 * Returns the route to access the WildFly/JBoss EAP application.
+	 *
+	 * @return the WildFly/JBoss EAP application route hostname
+	 */
+	public static String getRoute() {
+		return OpenShifts.master().generateHostname(APP_NAME);
+	}
+
+	/**
+	 * Returns an unmodifiable list of Kubernetes secrets.
+	 * <p>
+	 * The secrets include:
+	 * <ul>
+	 *   <li>SAML keystore for encryption and signing</li>
+	 *   <li>HTTPS truststore for secure communication with Keycloak</li>
+	 * </ul>
+	 * </p>
+	 *
+	 * @return unmodifiable list of Kubernetes secrets
+	 */
+	@Override
+	public List<Secret> getSecrets() {
+		return Collections.unmodifiableList(secrets);
+	}
+}


### PR DESCRIPTION
Resolves #63 

Tested in:

- WildFly: eap-8.x-cross-product-face#179

## Description

Introduce a new test named WildFlyKeycloakSamlAdapterEjbIT which is a variation over the existing WildFlyKeycloakSamlAdapterIT test which used SAML Dynamic Client Registration feature (see hhttps://github.com/wildfly/wildfly-cekit-modules/blob/main/jboss/container/wildfly/launch/keycloak/2.0/added/keycloak.sh for the details) and secures EJB resources;

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [x] I tested my code in OpenShift
