### PR TITLE
WildFlyBootableJarKeycloakSamlAdapterEjbHelmIT: exclude EAP

### DIFF
--- a/testsuite/src/test/java/org/jboss/intersmash/tests/wildfly/keycloak/saml/adapter/WildFlyBootableJarKeycloakSamlAdapterEjbHelmIT.java
+++ b/testsuite/src/test/java/org/jboss/intersmash/tests/wildfly/keycloak/saml/adapter/WildFlyBootableJarKeycloakSamlAdapterEjbHelmIT.java
@@ -29,7 +29,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.jboss.intersmash.annotations.Intersmash;
 import org.jboss.intersmash.annotations.Service;
 import org.jboss.intersmash.annotations.ServiceUrl;
-import org.jboss.intersmash.tests.junit.annotations.EapTest;
 import org.jboss.intersmash.tests.junit.annotations.EapXpTest;
 import org.jboss.intersmash.tests.junit.annotations.KeycloakTest;
 import org.jboss.intersmash.tests.junit.annotations.OpenShiftTest;
@@ -65,7 +64,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @WildflyTest
 // EAP 8.1: Bootable jar is not supported on OpenShift Container Platform.
 // See https://docs.redhat.com/en/documentation/red_hat_jboss_enterprise_application_platform/8.1/html-single/provisioning_jboss_eap/index
-@EapTest
 @EapXpTest
 @OpenShiftTest
 @ExtendWith(ProjectCreator.class)


### PR DESCRIPTION
## Description

Exclude WildFlyBootableJarKeycloakSamlAdapterEjbHelmIT from EAP testing;

CI Run not needed;

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] Code contributed by me aligns with current project license: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 - [x] Pull Request contains a description of the changes
 - [x] Pull Request does not include fixes for multiple issues/topics
 - [x] Code is self-descriptive and/or documented
 - [ ] I tested my code in OpenShift
